### PR TITLE
Adding compiled binaries in github releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,10 @@ jobs:
        - name: Upload artifact ddbpm-linux-release.zip
          uses: actions/upload-artifact@v3
          with:
-          name: ddbpm-linux-release
-          path: ./rel
+           name: ddbpm-linux-release
+           path: ./rel
+
+          
       # - name: Archive Release
       #   uses: thedoctor0/zip-release@0.7.5
       #   with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,5 @@
 name: deadbeef playlist manager plugin build
 
-on: [push,pull_request]
-
 jobs:
   build_linux:
     name: Linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,5 @@ jobs:
         uses: ncipollo/release-action@v1.12.0
         with:
           artifacts: "ddbpm-linux-release.zip"
-          # This line tells the action which tag to use
           tag: ${{ github.ref_name }} 
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,23 +21,14 @@ jobs:
           make
           mkdir ./rel
           mv ./*.so ./rel
-        
-      - name: Upload artifact ddbpm-linux-release.zip
-        uses: actions/upload-artifact@v3
-        with:
-          name: ddbpm-linux-release
-          path: ./rel
 
-          
-      # - name: Archive Release
-      #   uses: thedoctor0/zip-release@0.7.5
-      #   with:
-      #     type: 'zip'
-      #     filename: 'ddbpm-linux-release.zip'
-      #     path: ./rel
-      # - name: Upload Release
-      #   uses: ncipollo/release-action@v1.12.0
-      #   with:
-      #     artifacts: "ddbpm-linux-release.zip"
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-          
+      - name: Zip the directory
+        run: zip -r ddbpm-linux-release.zip ./rel 
+      
+      - name: Create Release
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          artifacts: "ddbpm-linux-release.zip"
+          # This line tells the action which tag to use
+          tag: ${{ github.ref_name }} 
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Get Deps
-        with:
-          update: true
-          install: >-
-            libgtk2.0-dev libgtk-3-dev
+        run: |
+            sudo apt-get update
+            sudo apt-get install -y libgtk2.0-dev libgtk-3-dev
+      - name: Get deadbeef.h
         run: |
           wget https://raw.githubusercontent.com/DeaDBeeF-Player/deadbeef/refs/heads/master/include/deadbeef/deadbeef.h ./deadbeef.h
       - name: Build the plugin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Build the plugin
         run: |
           make
-          mkdir ./rel
-          mv ./*.so ./rel
+          mkdir ./ddbpm-linux
+          mv ./*.so ./ddbpm-linux
 
       - name: Zip the directory
-        run: zip -r ddbpm-linux-release.zip ./rel 
+        run: zip -r ddbpm-linux-release.zip ./ddbpm-linux
       
       - name: Create Release
         uses: ncipollo/release-action@v1.12.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,3 +33,5 @@ jobs:
           artifacts: "ddbpm-linux-release.zip"
           tag: ${{ github.ref_name }} 
           token: ${{ secrets.GITHUB_TOKEN }}
+          allowUpdates: true
+          replacesArtifacts: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ jobs:
   build_linux:
     name: Linux
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: deadbeef playlist manager plugin build
+
+on: [push,pull_request]
+
+jobs:
+  build_linux:
+    name: Linux
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Get Deps
+        with:
+          update: true
+          install: >-
+            libgtk2.0-dev libgtk-3-dev
+        run: |
+          wget https://raw.githubusercontent.com/DeaDBeeF-Player/deadbeef/refs/heads/master/include/deadbeef/deadbeef.h ./deadbeef.h
+      - name: Build the plugin
+        run: |
+          make
+          mkdir ./rel
+          mv ./*.so ./rel
+      - name: Archive Release
+        uses: thedoctor0/zip-release@0.7.5
+        with:
+          type: 'zip'
+          filename: 'ddbpm-linux-release.zip'
+          path: ./rel
+      - name: Upload Release
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          artifacts: "ddbpm-linux-release.zip"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,12 @@ jobs:
           make
           mkdir ./rel
           mv ./*.so ./rel
-       - name: Upload artifact ddbpm-linux-release.zip
-         uses: actions/upload-artifact@v3
-         with:
-           name: ddbpm-linux-release
-           path: ./rel
+        
+      - name: Upload artifact ddbpm-linux-release.zip
+        uses: actions/upload-artifact@v3
+        with:
+          name: ddbpm-linux-release
+          path: ./rel
 
           
       # - name: Archive Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
             sudo apt-get install -y libgtk2.0-dev libgtk-3-dev
       - name: Get deadbeef.h
         run: |
-          wget https://raw.githubusercontent.com/DeaDBeeF-Player/deadbeef/refs/heads/master/include/deadbeef/deadbeef.h ./deadbeef.h
+          wget https://raw.githubusercontent.com/DeaDBeeF-Player/deadbeef/refs/heads/master/include/deadbeef/deadbeef.h -O ./deadbeef.h
       - name: Build the plugin
         run: |
           make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: deadbeef playlist manager plugin build
 
+on:
+  workflow_dispatch: {}
+
 jobs:
   build_linux:
     name: Linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,15 +21,20 @@ jobs:
           make
           mkdir ./rel
           mv ./*.so ./rel
-      - name: Archive Release
-        uses: thedoctor0/zip-release@0.7.5
-        with:
-          type: 'zip'
-          filename: 'ddbpm-linux-release.zip'
+       - name: Upload artifact ddbpm-linux-release.zip
+         uses: actions/upload-artifact@v3
+         with:
+          name: ddbpm-linux-release
           path: ./rel
-      - name: Upload Release
-        uses: ncipollo/release-action@v1.12.0
-        with:
-          artifacts: "ddbpm-linux-release.zip"
-          token: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Archive Release
+      #   uses: thedoctor0/zip-release@0.7.5
+      #   with:
+      #     type: 'zip'
+      #     filename: 'ddbpm-linux-release.zip'
+      #     path: ./rel
+      # - name: Upload Release
+      #   uses: ncipollo/release-action@v1.12.0
+      #   with:
+      #     artifacts: "ddbpm-linux-release.zip"
+      #     token: ${{ secrets.GITHUB_TOKEN }}
           


### PR DESCRIPTION
Hello, I added a github workflow that compiles the project using the existing makefile, zips the directory with those binaries and uploads that archive to github releases. This seems to work, I'm using the plugin binary which is the result of this workflow. I have a standard glibc system, not sure if this is gonna work on non-glibc systems. I haven't implemented any versioning here as this is the first time I'm doing this and I don't know how to do that, I'm also not aware how to track versions and if/how this project tracks versions.